### PR TITLE
Use native docker actions for docker mult-arch build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           - huginn/huginn-single-process
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKERFILE: docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
+      DOCKERFILE: ./docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
       DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
       DOCKER_PLATFORMS: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,34 @@ jobs:
       DOCKERFILE: docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
       DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build a docker image
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = push -a "$GITHUB_REF_NAME" = master ]; then
-            ./build_docker_image.sh --push
-          else
-            ./build_docker_image.sh
-          fi
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' && GITHUB_REF_NAME == 'master' }}
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           - huginn/huginn-single-process
     env:
       DOCKER_IMAGE: ${{ matrix.docker_image }}
-      DOCKERFILE: ./docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
+      DOCKERFILE: docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
       DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
       DOCKER_PLATFORMS: linux/amd64,linux/arm64
@@ -106,7 +106,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
-          context: ${{ env.DOCKERFILE }}
+          context: .
+          file: ${{ env.DOCKERFILE }}
           push: ${{ github.event_name != 'pull_request' && env.GITHUB_REF_NAME == 'master' }}
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.DOCKERFILE }}
-          push: ${{ github.event_name != 'pull_request' && GITHUB_REF_NAME == 'master' }}
+          push: ${{ github.event_name != 'pull_request' && env.GITHUB_REF_NAME == 'master' }}
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add setup-qemu and setup-buildx actions to give docker the ability to build multiple architecture builds
Remove call to `./build_docker_image.sh` 
Replace docker build script with build-push action from docker. Add basic metadata tagging.

REF: huginn/huginn#2648