### PR TITLE
Use native docker actions for docker mult-arch build (#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,35 @@ jobs:
       DOCKERFILE: docker/${{ contains(matrix.docker_image, 'single-process') && 'single-process' || 'multi-process' }}/Dockerfile
       DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build a docker image
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = push -a "$GITHUB_REF_NAME" = master ]; then
-            ./build_docker_image.sh --push
-          else
-            ./build_docker_image.sh
-          fi
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' && env.GITHUB_REF_NAME == 'master' }}
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Add setup-qemu and setup-buildx actions to give docker the ability to build multiple architecture builds
* Remove call to `./build_docker_image.sh` 
* Replace docker build script with build-push action from docker.
* Add basic metadata tagging.